### PR TITLE
1wt, 2wt, ... ( N-Wide Tileable ) before 1wABt, 2wABt, ...

### DIFF
--- a/data/dictionary.json
+++ b/data/dictionary.json
@@ -1,13 +1,13 @@
 [
+  {
+		"term": "1wt, 2wt, ... ( N-Wide Tileable )",
+		"tags": ["Feature"],
+		"description": "Annotates the width of a slice, and whether or not you can build them right next to eachother. There are systems that are 1 wide, but you can't put 2 next to eachother due to @Crosstalk, so they don't get this annotation. Sometimes they are @1wABt, 2wABt, ... instead."
+	},
 	{
 		"term": "1wABt, 2wABt, ...",
 		"tags": ["Feature"],
 		"description": "An extension of @1wt, 2wt, ... ( N-Wide Tileable ), but where a solution has been provided by the author on how to put 2 @Slices of the same system next to eachother, by moving/editing some components within the system. The capital letters ( AB, or ABC, or ABCD, ... ) annotate how the slices are tiled, and how many versions of the slice exist to achieve a result."
-	},
-	{
-		"term": "1wt, 2wt, ... ( N-Wide Tileable )",
-		"tags": ["Feature"],
-		"description": "Annotates the width of a slice, and whether or not you can build them right next to eachother. There are systems that are 1 wide, but you can't put 2 next to eachother due to @Crosstalk, so they don't get this annotation. Sometimes they are @1wABt, 2wABt, ... instead."
 	},
 	{
 		"term": "1x, 2x, 1/2x, ...",


### PR DESCRIPTION
The definition for 1wABt, 2wABt, ... relies on the definition of 1wt, 2wt, ... ( N-Wide Tileable ) yet it comes before; this pr would move 1wt, 2wt, ... ( N-Wide Tileable ) to come first.
<img width="1177" alt="Screen Shot 2022-08-12 at 3 34 51 PM" src="https://user-images.githubusercontent.com/91382906/184430716-b70eb6c7-d297-446d-8aeb-0665da9a260e.png">
