### PR TITLE
Cleanup, search improvements, new mess again

### DIFF
--- a/data/dictionary.yaml
+++ b/data/dictionary.yaml
@@ -1,33 +1,49 @@
 ---
 
-- term: 1 wide AB tileable, 2 wide AB tileable, ...
+- term: n-wide AB tileable
   aka:
-  - '1wABt... '
+  - 1wABt, 2wABt, ...
+  - nwABt
   tags:
   - Feature
-  description: An extension of @1wt, 2wt, ... ( N-Wide Tileable ), but where a solution
-    has been provided by the author on how to put 2 @Slices of the same system next
+  description: An extension of @[n-Wide tileable], but where a solution
+    has been provided by the author on how to put 2 @[Slices](Slice) of the same system next
     to eachother, by moving/editing some components within the system. The capital
     letters ( AB, or ABC, or ABCD, ... ) annotate how the slices are tiled, and how
     many versions of the slice exist to achieve a result.
 
-- term: 1 wide tileable, 2 wide tileable, ... ( N-Wide Tileable )
+- term: n-Wide tileable
   aka:
-  - 1wt, 2wt
+  - 1wt, 2wt, ...
+  - nwt
   tags:
   - Feature
   description: Annotates the width of a slice, and whether or not you can build them
     right next to eachother. There are systems that are 1 wide, but you can't put
-    2 next to eachother due to @Crosstalk, so they don't get this annotation. Sometimes
-    they are @1wABt, 2wABt, ... instead.
+    2 next to eachother due to @[Crosstalk], so they don't get this annotation. Sometimes
+    they are @[n-Wide Tileable] instead.
 
-- term: 1 * hopper speed, 2 * hopper speed
+- term: Hopper speed
   aka:
-  - 1x, 2x, 1/2x
+  - HS
+  - 1x, 2x, 1/2x, ...
   tags:
   - Feature
-  description: 'A way of quantifying speed of a system. The number is a multiplication
-    of @hs ( Hopper speed ) '
+  description: 'Refers to the speed at which items are processed in a hopper (1
+    item every 8@[gt](gametick)). Often used as a way of quantifying speed of a system 
+    in terms of how many hoppers worth of items are processed in or out. Usually written as an
+    integer or fraction (e.g. "3x or 1/2x hopper speed"). See also: @[Dropper speed].'
+
+- term: Dropper speed
+  aka:
+  - HS
+  - 1x, 2x, 1/2x, ...
+  tags:
+  - Feature
+  description: Similar to @[Hopper speed], but less frequently used. Refers to the speed at
+    which items are processed in a dropper when clocked at the minimum interval (1 item every 
+    4@[gt](gametick)). Usually written as an integer or fraction (e.g. "3x or 1/2x dropper speed"). 
+    1x Dropper speed is equal to 2x @[Hopper speed].
 
 - term: Aligner
   tags:
@@ -36,7 +52,7 @@
   description: It aligns items within a block to ensure some sort of behavior. More
     basic concepts involve simply letting items in a water or ice stream hit against
     a block with a certain hitbox, while more complex ones involve precisely timed
-    contraptions, see @Perfect aligner/4D alignment. The more simple usecases involve
+    contraptions, see @[Perfect aligner]. The more simple usecases involve
     using a chest, dragon egg, 2 or 3 stack of pickles, cake or some other block to
     align the items between two blocks such that they go over some hoppers and are
     inside a water stream at the same time. The use of different hitboxes allows for
@@ -69,8 +85,8 @@
   - bin
   tags:
   - Term
-  description: A code where each digit of the code is either on or off (we say it
-    has a binary state, usually represented with 0s and 1s. A four digit (@Bit ) signal
+  description: An encoding where each digit of a code is either on or off (we say it
+    has a binary state, usually represented with 0s and 1s). A four digit (@[Bit]) signal
     could have the states 0000 or 0110 or 0100, or any other combination of the valid
     states. In terms of minecraft, this usually translates to a wire or a rail being
     on or off, a piston being extended or retracted, a note block being powered or
@@ -79,7 +95,7 @@
 - term: Bit
   tags:
   - Term
-  description: 'Short for binary digit: the digits in a binary system.'
+  description: 'Short for binary digit: the digits in a @[binary] system.'
 
 - term: Box Comparer
   tags:
@@ -87,12 +103,12 @@
   description: "A Box Comparer is a contraption that takes two boxes as input, and
     compares them by signal strength. A Box comparer normally has dedicated outputs
     for the fuller and less full boxes.\n\nBox comparers are used in many contraptions,
-    one example is making sure that @Mergers get the fuller box in the correct input. "
+    one example is making sure that @[Mergers](Merger) get the fuller box in the correct input. "
 
 - term: Box Detection
   tags:
   - Feature
-  description: Usually used as a way to tag @Loaders and @Box Displays that restart
+  description: Usually used as a way to tag @[Loaders](Loader) and @[Box Displays](Box Display) that restart
     themselves when boxes come in and they were previously empty.
 
 - term: Box Display
@@ -114,7 +130,7 @@
   tags:
   - StorageTech Contraption
   description: 'A Box Sorter is a contraption that takes in boxes of a single item-type,
-    takes the first item out and assigns the box to a storage @Slice that matches
+    takes the first item out and assigns the box to a storage @[Slice] that matches
     the filter of that item. '
 
 - term: Block Update Detector
@@ -124,7 +140,7 @@
   - StorageTech Contraption
   - Term
   description: 'A Block Update detector is a device that has something happen when
-    it receives an update. Example: A piston that is @QC (Quasi connectivity) powered
+    it receives an update. Example: A piston that is @[Quasi-powered](Quasi connectivity)
     but not yet updated is called "BUDded", and will fire when updated. This term
     is sometimes used to refer to a component that is being QC powered by saying it''s
     "BUD powered".'
@@ -134,24 +150,24 @@
   - StorageTech Contraption
   description: At it's simplest, a bulk storage is just a system that stores a lot
     of items, usually a single type per module and in box form. The challenge usually
-    comes in trying to make the system compact, extremely lag friendly (through @Hopper-locked
-    storage and other techniques), and adding features like @Item Call and @Encoded
+    comes in trying to make the system compact, extremely lag friendly (through @[Hopper-locked]
+    storage and other techniques), and adding features like @[Item Call] and @[Encoded]
     storage.
 
 - term: Chest Hall
   tags:
   - StorageTech Contraption
-  description: A hall containing chests for items. It usually come in slices (@Slice)
+  description: A hall containing chests for items. It usually come in @[slices](slice)
     so that it can be stacked and extended as large as needed. They differ widely
     in functionality and amount of items available in each slice. Both encoded chest
     halls and fixed item sorter based chest halls exists. These are usually the main
-    @UI of a storage system.
+    @[UI] elements of a storage system.
 
 - term: Crosstalk
   tags:
   - Bad-Practice
   - Term
-  description: 'A term used for when 2 tiled @Slices are interfering with eachother
+  description: 'A term used for when 2 tiled @[Slices](slice) are interfering with eachother
     in any situation. '
 
 - term: Comparator Update Detector
@@ -170,11 +186,11 @@
   tags:
   - StorageTech Contraption
   - Term
-  description: 'Decoder has two main meanings in storage tech: A contraption that
-    translates code or data to item, like a an encoded storage hall, the inverse of
-    @encoding, or one that translates code into user-readable information, like a
+  description: 'A Decoder has two main meanings in storage tech: A contraption that
+    translates code or data to item, like a an encoded storage hall, the inverse of an
+    @[Encoder], or one that translates code into user-readable information, like a
     display. In addition, in computational redstone it''s sometimes used to mean increasing
-    the size of a base, bin to hex, for example, see @Transcoder.'
+    the size of a base, bin to hex, for example, see @[Transcoder].'
 
 - term: Directional
   tags:
@@ -195,23 +211,24 @@
 - term: Dust updateless
   tags:
   - Feature
-  description: Some contraptions are not @Dustless, but the dust they use does not
-    get updated (does not change @ss). This can be because it is either used to steadily
+  description: Some contraptions are not @[Dustless], but the dust they use does not
+    get updated (does not change @[ss](Signal Strength)). This can be because it is either used to steadily
     power a component, or because it's used by redirecting it, but not changing ss.
-    Redirecting dust is really lag friendly, as lag usage goes.
+    Redirecting dust is really lag friendly, as lag usage goes. These terms are therefore
+    often used interchangably.
 
 - term: Dustless
   tags:
   - Feature
   description: A contraption that makes no use of redstone dust. Redstone dust is
     one of the single most laggiest components in the game, since it gives 25 updates
-    for each @ss change. When increasing signal, it updates one for each increase
+    for each @[ss](Signal Strength) change. When increasing signal, it updates one for each increase
     level, so going from ss 3 to 7, for instance would give 100 block updates. Decreasing
     signal is different between versions 1.14- and 1.15+, where in the former it happens
     the same way it does when increasing values, and in the latter, it moves by steps
     of two, reducing the amount of updates by half. In 1.15+ dust dots (single dust)
     update all at once, without stepping through intermediary ss values. A big part
-    of the community also calls @Dust updateless contraptions Dustless, since the
+    of the community also calls @[Dust updateless] contraptions Dustless, since the
     updates is the only part of the dust that lags.
 
 - term: Encoded
@@ -219,33 +236,36 @@
   - Term
   description: A system is said to be encoded when a signal in the form of a code
     is used to decide the fate of items or boxes. In broader terms, it referres to
-    systems that use codes to transfer instructions. Codes can be a @Binary signal,
-    a @Hex (Hexadecimal) signal or, less often, octal or cuartal, with either multiple
+    systems that use codes to transfer instructions. Codes can be a @[Binary] signal,
+    a @[Hexadecimal] signal or, less often, octal or cuartal, with either multiple
     or single digits.
 
 - term: Encoder
   tags:
   - StorageTech Contraption
   - Term
-  description: 'Encoder has two main meanings in storage tech: A contraption that
+  description: 'An Encoder has two main meanings in storage tech: A contraption that
     translates items into a code, where code can be any sort of signal in any base
     (binn, hex, other less used ones) or other codes (block event delay), or a contraption
     that translates a player input (say a selection pannel) into code. In addition,
     in computational redstone, this sometimes referes to decreasing the size of the
-    base used in the code: hex to bin, for example, see @Transcoder .'
+    base used in the code: hex to bin, for example, see @[Transcoder].'
 
-- term: Fill Sorter, IsEmpty, isFull
+- term: Fill Sorter
+  aka: 
+  - IsEmpty
+  - IsFull
   tags:
   - StorageTech Contraption
   description: |-
-    A Fill Sorter is a @Box Separator that has different outputs based on how full the box is, usually Empty / Full / Partial.
+    A Fill Sorter is a @[Box Separator] that has different outputs based on how full the box is, usually Empty / Full / Partial.
     IsEmpty is a Fill Sorter that only has outputs for empty and not-empty ( Full / Partial )
     IsFull is a Fill Sorter that only has outputs for full and not-full ( Empty / Partial )
 
 - term: Filtered Loader
   tags:
   - StorageTech Contraption
-  description: A @Loader combined with an item filter that fills a box with just one
+  description: A @[Loader] combined with an item filter that fills a box with just one
     item type.
 
 - term: Fixed Sorter
@@ -257,18 +277,22 @@
 - term: Global Output
   tags:
   - Feature
-  description: A contraption, usually a @1wt, 2wt, ... ( N-Wide Tileable ) one, that
-    has only one output for all the @Slices, in contrast to one output per slice (see
-    @Slice Preservation / Local Output).
+  description: A contraption, usually a @[1-wide tileable](n-Wide Tileable) one, that
+    has only one output for all the @[Slices](Slice), in contrast to one output per slice (see
+    @[Slice] Preservation / Local Output).
 
 - term: Global/Local
   tags:
   - Term
   description: |-
-    Annotates if a signal comes from a global system ( a "brain" ), or from within a @Slice.
+    Annotates if a signal comes from a global system ( a "brain" ), or from within a @[Slice].
     For example, one global clock could send signals to 8 slices on an interval, or all 8 slices could have their own clock.
 
-- term: gt ( Gametick )/tick
+- term: Gametick
+  aka:
+  - gt
+  - tick
+  - t
   tags:
   - Term
   description: "Minecraft iteratively runs its processing code in a loop. One cycle
@@ -278,7 +302,7 @@
     if the server is lagging (>50mspt). \nOften confused with the less technical term
     \"redstone tick\". A redstone tick is in practice 2gt, as its origin comes from
     the default setting of a repeater. \nA default repeater when freshly placed is
-    a 2gt- or one redstone-tick.-repeater."
+    a 2gt- or one redstone-tick-repeater."
 
 - term: Hexadecimal
   aka:
@@ -287,7 +311,7 @@
   - Term
   description: 'A code where each digit of the code has 16 possible states (usually
     represented as 0 to 9 and then A to F). It''s most commonly implemented with signal
-    strength values, where @ss 0 represents 0, ss10 represents A, ss15 represents
+    strength values, where @[ss](Signal Strength) 0 represents 0, ss10 represents A, ss15 represents
     F and so on. Multiple hex signals can be combined to form a code with multiple
     digits. For example, valid three digit hex codes are 032, AFF, 0F4. '
 
@@ -297,14 +321,6 @@
   description: Used to tag contraptions that lock their hoppers when the hoppers are
     not needed. This is because hoppers are otherwise very laggy.
 
-- term: Hopper speed
-  aka:
-  - HS
-  tags:
-  - Feature
-  description: Referred to the speed at which items are processed in a hopper ( 1
-    item every 8 gt )
-
 - term: Item Call
   tags:
   - Feature
@@ -312,14 +328,16 @@
   description: A device, mechanism or feature that allows the user to request items.
     The requested items may land in a user accessible inventory or be used to restock
     some component. Some systems can also use item call to automatically restock,
-    for example from @Bulk Storage.
+    for example from @[Bulk Storage].
 
-- term: Keygen, Item Wanker
+- term: Keygen
+  aka: 
+  - Item Wanker
   tags:
   - StorageTech Contraption
-  description: Usually part of a @Box Sorter , a keygen is a contraption that takes
+  description: Usually part of a @[Box Sorter], a keygen is a contraption that takes
     one item out of a box, breaks it and sends the item and sends one through one
-    hopper or @Dropperline  and the other through another one, with some delay.
+    hopper or @[Dropperline] and the other through another one, with some delay.
 
 - term: Loader
   tags:
@@ -342,9 +360,9 @@
   tags:
   - StorageTech Contraption
   - Term
-  description: A Liquid Update Detector is a device that uses liquids to detect a
-    special set of updates, some of which can be detected with a @BUD ( Block Update
-    Detector ), with a @CUD ( Comparator Update Detector ) or with an observer, but
+  description: A Liquid Update Detector (LUD) is a device that uses liquids to detect a
+    special set of updates, some of which can be detected with a @[Block Update
+    Detector], with a @[Comparator Update Detector] or with an observer, but
     some of which are exclusively detected by LUDs. After detecting the update and
     triggering, it usually resets the liquid to a state where it can detect an update
     again.
@@ -354,7 +372,8 @@
   - StorageTech Contraption
   description: |-
     A Merger is a contraption that takes 2 boxes as input, and merges them into one.
-    Mergers can work of mixed boxes, however most mergers assume that both boxes only contain one itemtype and are often used in conjunction with @Splitters.
+    Mergers can work of mixed boxes, however most mergers assume that both boxes only 
+    contain one itemtype and are often used in conjunction with @[Splitters](Splitter).
 
 - term: Multi Item Sorter
   aka:
@@ -368,16 +387,19 @@
 - term: Mixed Box
   tags:
   - Term
-  description: A box with multiple item types.
+  description: A shulker box with multiple item types.
 
 - term: Mixed loader
   tags:
   - StorageTech Contraption
-  description: A @Loader  that can handle multiple itemtypes going to the same box.
+  description: A @[Loader]  that can handle multiple itemtypes going to the same box.
     Fullness detection is usually done by reading that items are backing up in the
     container ( hopper / dropper ) feeding the box.
 
-- term: Pair Searcher/Finder/Assembler
+- term: Pair Searcher
+  aka: 
+  - Pair Finder
+  - Pair Assembler
   tags:
   - StorageTech Contraption
   description: A pair searcher is a contraption that takes in multiple boxes (usually
@@ -390,15 +412,17 @@
   - Term
   description: A code is said to be parallel if the all the bits of the signal are
     sent through individual wires or lines This usually allows for faster and easier
-    to use codes than @Serial codes, but it tends to be more expensive and bigger.
+    to use codes than @[Serial codes], but it tends to be more expensive and bigger.
 
-- term: Perfect aligner/4D alignment
+- term: Perfect aligner
+  aka:
+  - 4D aligner
   tags:
   - StorageTech Contraption
   description: 'Perfect item aligner referes to a contraption that aligns items in
     all three axes before sending them down a stream, where they usually get picked
-    up by hoppers. Since these contraptions are usually ran at @hs ( Hopper speed
-    ), the items need to have a perfect timing between them, so that they don''t reach
+    up by hoppers. Since these contraptions are usually ran at @[Hopper speed], 
+    the items need to have a perfect timing between them, so that they don''t reach
     a hopper during its cooldown stage, hence why these are also called 4D aligners
     (3D+time). '
 
@@ -413,7 +437,7 @@
   - Feature
   description: A contraption that makes no use of pistons. This is to reduce client-side
     lag due to tile entities in 1.16+ and general server-side lag, since each piston
-    has to check all the @TE ( Tile Entity ) / BE ( Block Entity ) in the world each
+    has to check all the @[Tile Entities](Tile Entity) in the world each
     time it tries to extend, and storage systems tend to have a lot of TEs. This effect
     is partly mitigated in 1.17+ and greatly mitigate by the Lithium mod.
 
@@ -429,8 +453,7 @@
 - term: Precision Loader
   tags:
   - StorageTech Contraption
-  description: 'A @Loader that makes use of a @Precision Hopper to achieve@Slice Preservation
-    / Local Output '
+  description: 'A @[Loader] that makes use of a @[Precision Hopper] to achieve @[Slice Preservation]'
 
 - term: Quasi connectivity
   aka:
@@ -442,8 +465,8 @@
     lamp above the component. If that lamp was to be on in that location, the block
     is quasi-powered. Quasi-powering usually doesn't update the component being QCed,
     which results in the component not "realizing" it should activate or deactivate
-    until it recieves an updated. For this reason, QC is often  used for @BUD ( Block
-    Update Detector ), and people even sometimes say "BUD powered" rather than "quasi
+    until it recieves an updated. For this reason, QC is often  used for @[Block
+    Update Detector], and people even sometimes say "BUD powered" rather than "quasi
     powered".
 
 - term: Sequential Sorter
@@ -456,14 +479,14 @@
   - Term
   description: A code is said to be serial if the bits of the signal are sent one
     after the other through a single wire. This is more space and resource efficient
-    than @Parallel codes, but usually slower and harder to implement.
+    than @[Parallel codes], but usually slower and harder to implement.
 
 - term: Serializer/Deserializer
   tags:
   - StorageTech Contraption
-  description: Components used to convert @Serial codes into @Parallel codes or viceversa.
-    These sometimes also act as @Encoders or @Decoders, in the computational redstone
-    sense. For example serial hex to parallel binary is a deserializer encoder.
+  description: Components used to convert @[Serial codes] into @[Parallel codes] or viceversa.
+    These sometimes also act as @[Encoders](Encoder) or @[Decoders](Decoder), in the computational 
+    redstone sense. For example serial hex to parallel binary is a deserializer encoder.
 
 - term: Silent
   tags:
@@ -478,35 +501,37 @@
   - Term
   description: A repeatable ( Preferrably tileable ) component within a system.
 
-- term: Slice Preservation / Local Output
+- term: Slice Preservation
+  aka: 
+  - Local Output
   tags:
   - Feature
   description: A contraption is said to be slice preserving if it outputs the shulker
-    boxes or items within the slice, in contrast to @Global Output, where there's
-    one output for all @Slices. This term is mostly used for @1wt, 2wt, ... ( N-Wide
-    Tileable ) contraptions. Since some systems are only mostly slice preserving,
+    boxes or items within the slice, in contrast to @[Global Output], where there's
+    one output for all @[Slices](Slice). This term is mostly used for @[1-Wide Tileable](N-Wide
+    Tileable) contraptions. Since some systems are only mostly slice preserving,
     but fail to be so in some specific condition or with a very low change, some people
     use the term perfect slice preservation for a system that does not have said flaws.
 
 - term: Smart box display
   tags:
   - StorageTech Contraption
-  description: A @Box Display that will only break the shulker box when it's both
+  description: A @[Box Display] that will only break the shulker box when it's both
     empty and closed.
 
 - term: Solid state
   tags:
   - Feature
   description: A contraption that has no moving parts or, more loosely, that has no
-    pistons spitting blocks, or other forms of @Toggle state. This term is also sometimes
-    interchangeably used with @Pistonless, although you can have a solid state contraption
+    pistons spitting blocks, or other forms of @[Toggle state]. This term is also sometimes
+    interchangeably used with @[Pistonless], although you can have a solid state contraption
     (in the loose way) with pistons by having them never spit out the block, i.e.
     powering them with long pulses only.
 
 - term: Splitter
   tags:
   - StorageTech Contraption
-  description: A Splitter is a contraption that takes a @Mixed Box as input and unloads
+  description: A Splitter is a contraption that takes a @[Mixed Box] as input and unloads
     the box into one box per item type.
 
 - term: ss
@@ -514,14 +539,17 @@
   - Term
   description: Abbrevation for signal strength
 
-- term: Tile Entity / Block Entity
+- term: Tile Entity
   aka:
-  - TE, BE
+  - Block Entity
+  - TE
+  - BE
   tags:
   - Term
   description: |-
     Used interchangeably.
-    Tile entities are blocks that have NBT-data attached to them, for example all blocks with inventories and comparators
+    Tile entities (less often referred to as Block Entities) are blocks that have NBT-data 
+    attached to them, for example all blocks with inventories and comparators
     More information here: https://minecraft.fandom.com/wiki/Block_entity
 
 - term: Temp Storage
@@ -530,8 +558,8 @@
   description: Short for "temporary storage". It's not a way to refer to a storage
     system that will only be used temporarily. It refers to a storage system in which
     boxes are stored temporarily, usually until a second box of the same item type
-    reaches the system and they can be combined in a @Merger and then be sent to a
-    more final storage (like @Bulk Storage, @Chest Hall or others).
+    reaches the system and they can be combined in a @[Merger] and then be sent to a
+    more final storage (like @[Bulk Storage], @[Chest Hall] or others).
 
 - term: Toggle state
   tags:
@@ -556,7 +584,7 @@
   tags:
   - StorageTech Contraption
   description: 'A device or contraption to convert between encodings of a signal:
-    @Binary to @Hex (Hexadecimal), hex to octal, pulse length to binary, block event
+    @[Binary] to @[Hexadecimal], hex to octal, pulse length to binary, block event
     delay to overloaded comparator, etc.'
 
 - term: Tile Tick Priority
@@ -564,7 +592,7 @@
   - ttp
   tags:
   - Term
-  description: Usually used when referring to pointing Comparators in @Dropperlines
+  description: Usually used when referring to pointing Comparators in @[Dropperlines](Dropperline)
     into repeaters/comparators increase the priority of the comparator and allow it
     to actually notice that an item is coming through
 
@@ -589,13 +617,14 @@
   description: 'An item sorter that sorts unstackable items into different categories.
     Regular item sorters can not be used for this usecase, because the items don''t
     stack, so unique behaviors of each item type have to be used in order to separate
-    them. Not to be confused with @Unstackable filter '
+    them. Not to be confused with @[Unstackable filter] '
 
 - term: Variable sorter
   tags:
   - StorageTech Contraption
-  description: |-
-    An item filter that does not always filter for the same item, but instead can be remapped, meaning getting the item type reasigned (in contrast with @Fixed Sorter). There are many different types of variable sorters :
+  description: 'An item filter that does not always filter for the same item, but instead can be remapped, 
+    meaning getting the item type reasigned (in contrast with @[Fixed Sorter]). There are many 
+    different types of variable sorters:
     * Timer-based variable sorters unmap when a timer runs out.
     * Self-resetting variable sorters try to unmap constantly but fail if more items come in of the same type.
-    * Globally-Triggered variable sorters unmap when receiving a signal from a global trigger
+    * Globally-Triggered variable sorters unmap when receiving a signal from a global trigger'


### PR DESCRIPTION
Technical upkeep, including:
- getting rid of a bunch of legacy code
- making sure the search function doesn't break links
- added quoted search, which matches only the exact term inside
- making entry-mentions link with a quoted search
- making an even bigger mess of spaghetti code <3

The search functionality and search highlighting are both a bit of a mess right now, this is all based on Property Encyclopedia code that's about a year old at this point, but it works for now. 
