### PR TITLE
ss2 and ss3 definitions

### DIFF
--- a/data/dictionary.yaml
+++ b/data/dictionary.yaml
@@ -578,6 +578,33 @@
     @[Decoders](Decoder), in the computational redstone sense. For example
     serial hex to parallel binary is a deserializer encoder.
 
+- term: Signal Strength 2 Filter
+  aka:
+    - SS2 filter
+  tags:
+    - StorageTech Concept
+    - Feature
+    - Bad Practice
+  description: >-
+    An item filter that relies on powering just two pieces of redstone dust
+    before letting items flow through. Tiling two identical SS2 filters next to
+    each other can cause @[crosstalk] if one of the slots of the hopper fill up 
+    completely. This would cause the adjacent filter to break, and is therefore
+    considered bad practice, unless mitigated by using signal strength isolated 
+    filters that have been @[AB-tiled](n-wide AB tileable).
+
+- term: Signal Strength 3 Filter
+  aka:
+    - SS3 filter
+  tags:
+    - StorageTech Concept
+    - Feature
+  description: >-
+    An item filter that works by powering 3 pieces of redstone dust before
+    letting items flow. Unlike @[SS2] filters, SS3 filters can be
+    @[tiled](n-Wide tileable) without @[alternating slices](n-Wide AB-tileable)
+    and still be overflow-proof.
+
 - term: Silent
   tags:
     - Feature


### PR DESCRIPTION
```yaml
- term: Signal Strength 2 Filter
  aka:
    - SS2 filter
  tags:
    - StorageTech Concept
    - Feature
    - Bad Practice
  description: >-
    An item filter that relies on powering just two pieces of redstone dust
    before letting items flow through. Tiling two identical SS2 filters next to
    each other can cause @[crosstalk] if one of the slots of the hopper fill up 
    completely. This would cause the adjacent filter to break, and is therefore
    considered bad practice, unless mitigated by using signal strength isolated 
    filters that have been @[AB-tiled](n-wide AB tileable).

- term: Signal Strength 3 Filter
  aka:
    - SS3 filter
  tags:
    - StorageTech Concept
    - Feature
  description: >-
    An item filter that works by powering 3 pieces of redstone dust before
    letting items flow. Unlike @[SS2] filters, SS3 filters can be
    @[tiled](n-Wide tileable) without @[alternating slices](n-Wide AB-tileable)
    and still be overflow-proof.
```